### PR TITLE
Update eg003ListEnvelopes.ps1

### DIFF
--- a/examples/eSignature/eg003ListEnvelopes.ps1
+++ b/examples/eSignature/eg003ListEnvelopes.ps1
@@ -18,7 +18,7 @@ Write-Output "Sending the list envelope status request to DocuSign..."
 Write-Output "Results:"
 
 # Get date in the ISO 8601 format
-$fromDate = ((Get-Date).AddDays(-10d)).ToString("yyyy-MM-ddThh:mm:ssK")
+$fromDate = ((Get-Date).AddDays(-10d)).ToString("yyyy-MM-ddTHH:mm:ssK")
 
 
 $(Invoke-RestMethod `


### PR DESCRIPTION
Set to 24h time, if the HH is lowercase it causes glitches if you change the .AddDays to .AddHours

For example,

If you use -3h in the addhours it would only use AM and cause duplications. to fix this you change the format for the hours to 24h time or military time. 